### PR TITLE
Add modality dropout helper and tests

### DIFF
--- a/finetune_scripts/__init__.py
+++ b/finetune_scripts/__init__.py
@@ -2,3 +2,7 @@
 Fine-tuning scripts for survival analysis.
 Contains scripts and utilities for fine-tuning pretrained models for survival prediction.
 """
+
+from .modality_dropout import apply_modality_dropout
+
+__all__ = ["apply_modality_dropout"]

--- a/finetune_scripts/modality_dropout.py
+++ b/finetune_scripts/modality_dropout.py
@@ -1,0 +1,77 @@
+import torch
+
+def apply_modality_dropout(
+    h_img: torch.Tensor,
+    h_tab: torch.Tensor,
+    p_img: float,
+    p_tab: float,
+    tab_group_masks: dict[str, torch.Tensor] | None,
+    training: bool
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Apply modality and group-level dropout with availability masks.
+
+    Args:
+        h_img: Image modality features ``[B, E]``.
+        h_tab: Tabular modality features ``[B, E]``.
+        p_img: Probability of dropping the entire image modality.
+        p_tab: Probability of dropping the entire tabular modality.
+        tab_group_masks: Optional mapping of group name to mask ``[B, F_g]``.
+            Used to randomly drop individual groups when training.
+        training: If ``True`` dropout is applied, otherwise inputs are returned
+            unchanged.
+
+    Returns:
+        Tuple ``(h_img_out, h_tab_out, mask_img, mask_tab)`` where ``mask_*`` are
+        ``[B]`` tensors indicating availability of each modality.
+    """
+    B = h_img.shape[0]
+    device = h_img.device
+
+    h_img_out = h_img.clone()
+    h_tab_out = h_tab.clone()
+
+    # Initialize masks as ones (available)
+    mask_img = torch.ones(B, device=device, dtype=h_img.dtype)
+    mask_tab = torch.ones(B, device=device, dtype=h_tab.dtype)
+
+    if training:
+        if p_img > 0:
+            keep_img = torch.bernoulli(torch.full((B,), 1 - p_img, device=device))
+            mask_img = keep_img.to(h_img.dtype)
+            h_img_out = h_img_out * keep_img.view(-1, 1)
+
+        if p_tab > 0:
+            keep_tab = torch.bernoulli(torch.full((B,), 1 - p_tab, device=device))
+            mask_tab = keep_tab.to(h_tab.dtype)
+            h_tab_out = h_tab_out * keep_tab.view(-1, 1)
+
+        # Group dropout for tabular features
+        if tab_group_masks:
+            start = 0
+            for mask in tab_group_masks.values():
+                width = mask.shape[1]
+                end = start + width
+                group_feats = h_tab_out[:, start:end]
+                # Respect existing mask from data
+                group_feats = group_feats * mask.to(h_tab_out.device)
+                # Randomly drop the entire group with Bernoulli(0.5)
+                drop = torch.bernoulli(torch.full((B, 1), 0.5, device=device))
+                group_feats = group_feats * drop
+                h_tab_out[:, start:end] = group_feats
+                start = end
+
+        # Update availability masks after dropout
+        mask_img = (h_img_out.abs().sum(dim=1) > 0).to(h_img.dtype)
+        mask_tab = (h_tab_out.abs().sum(dim=1) > 0).to(h_tab.dtype)
+    else:
+        if tab_group_masks:
+            start = 0
+            for mask in tab_group_masks.values():
+                width = mask.shape[1]
+                end = start + width
+                h_tab_out[:, start:end] = h_tab_out[:, start:end] * mask.to(h_tab_out.device)
+                start = end
+        mask_img = (h_img_out.abs().sum(dim=1) > 0).to(h_img.dtype)
+        mask_tab = (h_tab_out.abs().sum(dim=1) > 0).to(h_tab.dtype)
+
+    return h_img_out, h_tab_out, mask_img, mask_tab

--- a/tests/test_modality_dropout.py
+++ b/tests/test_modality_dropout.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+import torch
+
+# Directly import module without triggering project package import
+sys.path.insert(0, str(Path(__file__).parent.parent / "finetune_scripts"))
+from modality_dropout import apply_modality_dropout
+
+
+def test_modality_dropout_masks():
+    torch.manual_seed(42)
+    B, E = 4, 3
+    h_img = torch.ones(B, E)
+    h_tab = torch.ones(B, E)
+
+    # Expected masks using same RNG sequence
+    expected_mask_img = torch.bernoulli(torch.full((B,), 0.5))
+    expected_mask_tab = torch.bernoulli(torch.full((B,), 0.5))
+
+    torch.manual_seed(42)
+    h_img_out, h_tab_out, mask_img, mask_tab = apply_modality_dropout(
+        h_img, h_tab, p_img=0.5, p_tab=0.5, tab_group_masks=None, training=True
+    )
+
+    assert torch.equal(mask_img, expected_mask_img)
+    assert torch.equal(mask_tab, expected_mask_tab)
+    assert torch.equal(mask_img, (h_img_out.abs().sum(dim=1) > 0).float())
+    assert torch.equal(mask_tab, (h_tab_out.abs().sum(dim=1) > 0).float())
+
+
+def test_group_dropout_masks():
+    torch.manual_seed(0)
+    B = 2
+    group_sizes = [2, 2]
+    E = sum(group_sizes)
+    h_img = torch.ones(B, E)
+    h_tab = torch.ones(B, E)
+    group_masks = {f"g{i}": torch.ones(B, size) for i, size in enumerate(group_sizes)}
+
+    # Expected group keep masks
+    torch.manual_seed(0)
+    keep_g1 = torch.bernoulli(torch.full((B, 1), 0.5))
+    keep_g2 = torch.bernoulli(torch.full((B, 1), 0.5))
+    expected_tab = torch.cat([
+        torch.ones(B, group_sizes[0]) * keep_g1,
+        torch.ones(B, group_sizes[1]) * keep_g2,
+    ], dim=1)
+    expected_mask_tab = (expected_tab.abs().sum(dim=1) > 0).float()
+
+    torch.manual_seed(0)
+    h_img_out, h_tab_out, mask_img, mask_tab = apply_modality_dropout(
+        h_img, h_tab, p_img=0.0, p_tab=0.0, tab_group_masks=group_masks, training=True
+    )
+
+    assert torch.equal(h_img_out, h_img)
+    assert torch.allclose(h_tab_out, expected_tab)
+    assert torch.equal(mask_img, torch.ones(B))
+    assert torch.equal(mask_tab, expected_mask_tab)


### PR DESCRIPTION
## Summary
- add `apply_modality_dropout` utility for modality and group-level dropout
- expose helper in fine-tuning package
- add unit tests covering dropout and mask behavior

## Testing
- `pytest tests/test_modality_dropout.py -q` *(fails: ModuleNotFoundError: No module named 'data')*
- `python - <<'PY' …`

------
https://chatgpt.com/codex/tasks/task_e_68bbb36de374832fbd9fa121a6e1fdba