### PR TITLE
Add event-aware batch samplers and DDP utilities

### DIFF
--- a/finetune_scripts/training_utils.py
+++ b/finetune_scripts/training_utils.py
@@ -4,11 +4,16 @@ Contains functions for model loading, epoch execution, and training loop managem
 """
 
 import os
+import math
+from typing import Iterator, List, Sequence
+
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import torch.distributed as dist
 from torch.nn.parallel import DataParallel, DistributedDataParallel as DDP
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Sampler
 
 from architectures import build_network, build_multimodal_network
 from losses import cox_ph_loss, concordance_pairwise_loss, time_aware_triplet_loss
@@ -18,6 +23,186 @@ from .distributed_utils import (
     setup_ddp_model, reduce_tensor, synchronize_distributed,
     get_optimal_batch_size_per_gpu, get_optimal_num_workers
 )
+
+
+class EventAwareBatchSampler(Sampler[List[int]]):
+    """Batch sampler ensuring a minimum number of event samples per batch.
+
+    Parameters
+    ----------
+    events : Sequence[int]
+        Binary event indicators for the dataset.
+    batch_size : int
+        Number of samples per batch.
+    m_events_per_batch : int, optional
+        Minimum number of event samples per batch. Defaults to 1.
+    num_batches : int, optional
+        Number of batches per epoch. If ``None`` it is computed from the
+        dataset length.
+    agatston_bins : Sequence[int], optional
+        Optional Agatston bin label for each sample enabling stratified
+        sampling across bins.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        events: Sequence[int],
+        batch_size: int,
+        m_events_per_batch: int = 1,
+        num_batches: int | None = None,
+        agatston_bins: Sequence[int] | None = None,
+        seed: int | None = None,
+    ) -> None:
+        self.events = np.asarray(events).astype(bool)
+        self.batch_size = int(batch_size)
+        self.m_events = int(m_events_per_batch)
+        n = len(self.events)
+        self.num_batches = num_batches or math.ceil(n / batch_size)
+        self.event_idx = np.where(self.events)[0]
+        self.censor_idx = np.where(~self.events)[0]
+        self.seed = seed
+
+        if agatston_bins is not None:
+            bins = np.asarray(agatston_bins)
+            self.unique_bins = np.unique(bins)
+            self.event_bins = {
+                b: self.event_idx[bins[self.event_idx] == b] for b in self.unique_bins
+            }
+            self.censor_bins = {
+                b: self.censor_idx[bins[self.censor_idx] == b] for b in self.unique_bins
+            }
+            bin_counts = np.array([np.sum(bins == b) for b in self.unique_bins], dtype=float)
+            self.bin_probs = bin_counts / bin_counts.sum()
+        else:
+            self.unique_bins = None
+            self.event_bins = None
+            self.censor_bins = None
+
+    def _sample_from_pool(
+        self, pool: np.ndarray, n: int, rng: np.random.Generator
+    ) -> np.ndarray:
+        if n <= 0 or len(pool) == 0:
+            return np.array([], dtype=int)
+        replace = len(pool) < n
+        return rng.choice(pool, size=n, replace=replace)
+
+    def _sample_stratified(
+        self, pools: dict[int, np.ndarray], n: int, rng: np.random.Generator
+    ) -> np.ndarray:
+        if n <= 0 or pools is None:
+            return np.array([], dtype=int)
+        counts = rng.multinomial(n, self.bin_probs)
+        samples: list[np.ndarray] = []
+        for b, c in zip(self.unique_bins, counts):
+            if c == 0:
+                continue
+            pool = pools.get(b, np.array([], dtype=int))
+            if len(pool) == 0:
+                continue
+            replace = len(pool) < c
+            samples.append(rng.choice(pool, size=c, replace=replace))
+        if samples:
+            return np.concatenate(samples)
+        return np.array([], dtype=int)
+
+    def __iter__(self) -> Iterator[List[int]]:
+        rng = np.random.default_rng(self.seed)
+        for _ in range(self.num_batches):
+            n_events = self.m_events if len(self.event_idx) > 0 else 0
+            if self.unique_bins is not None:
+                ev = self._sample_stratified(self.event_bins, n_events, rng)
+                n_non = self.batch_size - ev.shape[0]
+                non = self._sample_stratified(self.censor_bins, n_non, rng)
+            else:
+                ev = self._sample_from_pool(self.event_idx, n_events, rng)
+                n_non = self.batch_size - ev.shape[0]
+                non = self._sample_from_pool(self.censor_idx, n_non, rng)
+            batch = np.concatenate([ev, non])
+            rng.shuffle(batch)
+            yield batch.tolist()
+
+    def __len__(self) -> int:
+        return self.num_batches
+
+
+class EventAwareDistributedBatchSampler(Sampler[List[int]]):
+    """Distributed version of :class:`EventAwareBatchSampler` for DDP."""
+
+    def __init__(
+        self,
+        events: Sequence[int],
+        batch_size: int,
+        m_events_per_batch: int = 1,
+        num_batches: int | None = None,
+        agatston_bins: Sequence[int] | None = None,
+        seed: int = 0,
+        rank: int | None = None,
+        world_size: int | None = None,
+    ) -> None:
+        if world_size is None:
+            world_size = dist.get_world_size() if dist.is_initialized() else 1
+        if rank is None:
+            rank = dist.get_rank() if dist.is_initialized() else 0
+        self.rank = rank
+        self.world_size = world_size
+        self.sampler = EventAwareBatchSampler(
+            events,
+            batch_size,
+            m_events_per_batch,
+            num_batches=num_batches,
+            agatston_bins=agatston_bins,
+            seed=seed + rank,
+        )
+
+    def __iter__(self) -> Iterator[List[int]]:
+        return iter(self.sampler)
+
+    def __len__(self) -> int:
+        return len(self.sampler)
+
+    def set_epoch(self, epoch: int) -> None:
+        """Set the epoch for deterministic shuffling across epochs."""
+        self.sampler.seed = epoch + self.rank
+
+
+def all_gather_no_grad(*tensors: torch.Tensor) -> list[torch.Tensor]:
+    """All-gather tensors across processes without tracking gradients."""
+
+    if not (dist.is_available() and dist.is_initialized()):
+        return list(tensors)
+
+    world_size = dist.get_world_size()
+    results: list[torch.Tensor] = []
+    with torch.no_grad():
+        for tensor in tensors:
+            local_size = torch.tensor(tensor.shape[0], device=tensor.device, dtype=torch.long)
+            size_list = [torch.zeros_like(local_size) for _ in range(world_size)]
+            dist.all_gather(size_list, local_size)
+            max_size = int(torch.stack(size_list).max().item())
+            if tensor.shape[0] < max_size:
+                pad_shape = (max_size - tensor.shape[0],) + tensor.shape[1:]
+                padding = torch.zeros(pad_shape, device=tensor.device, dtype=tensor.dtype)
+                tensor_padded = torch.cat([tensor, padding], dim=0)
+            else:
+                tensor_padded = tensor
+            gather_list = [torch.zeros_like(tensor_padded) for _ in range(world_size)]
+            dist.all_gather(gather_list, tensor_padded)
+            trimmed = [t[:s.item()] for t, s in zip(gather_list, size_list)]
+            results.append(torch.cat(trimmed, dim=0))
+    return results
+
+
+def build_global_risk_tensors(
+    log_risk: torch.Tensor, time: torch.Tensor, event: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Gather per-process risk tensors into global tensors."""
+
+    if not (dist.is_available() and dist.is_initialized()):
+        return log_risk, time, event
+    gathered = all_gather_no_grad(log_risk, time, event)
+    return tuple(gathered)  # type: ignore[return-value]
 
 
 def load_model(resnet_type: str, init_mode: str, pretrained_path: str, device: torch.device) -> nn.Module:

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from finetune_scripts.training_utils import (
+    EventAwareBatchSampler,
+    EventAwareDistributedBatchSampler,
+)
+
+
+def test_event_aware_batch_sampler_min_events():
+    events = [0] * 20
+    events[2] = 1
+    events[10] = 1
+    events[15] = 1  # three events in dataset
+    sampler = EventAwareBatchSampler(events, batch_size=6, m_events_per_batch=2, seed=42)
+    for batch in sampler:
+        event_count = sum(events[i] for i in batch)
+        assert event_count >= 2
+
+
+def test_event_aware_distributed_batch_sampler_min_events():
+    events = [0] * 20
+    events[3] = 1
+    events[12] = 1
+    batch_size = 4
+    m_events = 1
+    sampler0 = EventAwareDistributedBatchSampler(
+        events,
+        batch_size=batch_size,
+        m_events_per_batch=m_events,
+        num_batches=5,
+        seed=0,
+        rank=0,
+        world_size=2,
+    )
+    sampler1 = EventAwareDistributedBatchSampler(
+        events,
+        batch_size=batch_size,
+        m_events_per_batch=m_events,
+        num_batches=5,
+        seed=0,
+        rank=1,
+        world_size=2,
+    )
+    for b0, b1 in zip(sampler0, sampler1):
+        count0 = sum(events[i] for i in b0)
+        count1 = sum(events[i] for i in b1)
+        assert count0 >= m_events
+        assert count1 >= m_events


### PR DESCRIPTION
## Summary
- add EventAwareBatchSampler and EventAwareDistributedBatchSampler to ensure minimum events per batch with optional Agatston stratification
- introduce all_gather_no_grad and build_global_risk_tensors for gathering uneven batches in distributed training
- test sampler behaviour on datasets with sparse events

## Testing
- `python -m pytest tests/test_sampler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbbb73c6b8832f89fe19d340d92d11