### PR TITLE
Add Swin3D and FT-Transformer encoders for multimodal survival models

### DIFF
--- a/architectures/__init__.py
+++ b/architectures/__init__.py
@@ -5,6 +5,8 @@ Architectures module for survival analysis models.
 from .resnet3d import build_network, print_resnet3d_param_counts
 from .multimodal_survival import build_multimodal_network, MultimodalSurvivalNet
 from .fusion import CrossAttentionFiLMFusion
+from .swin3d import Swin3DEncoder
+from .ft_transformer import FTTransformer
 
 __all__ = [
     'build_network',
@@ -12,4 +14,6 @@ __all__ = [
     'build_multimodal_network',
     'MultimodalSurvivalNet',
     'CrossAttentionFiLMFusion',
+    'Swin3DEncoder',
+    'FTTransformer',
 ]

--- a/architectures/ft_transformer.py
+++ b/architectures/ft_transformer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from typing import List, Optional
+
+
+class FTTransformer(nn.Module):
+    """Implementation of the FT-Transformer for tabular data.
+
+    References
+    ----------
+    Gorishniy et al., *Revisiting Deep Learning Models for Tabular Data*,
+    NeurIPS 2021.
+    """
+
+    def __init__(
+        self,
+        num_numeric: int,
+        cat_cardinalities: Optional[List[int]] | None,
+        embed_dim: int = 256,
+        n_heads: int = 4,
+        depth: int = 2,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_numeric = num_numeric
+        self.cat_cardinalities = cat_cardinalities or []
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.num_linear = nn.Linear(1, embed_dim) if num_numeric > 0 else None
+        self.cat_embeddings = nn.ModuleList(
+            [nn.Embedding(card, embed_dim) for card in self.cat_cardinalities]
+        )
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=embed_dim,
+            nhead=n_heads,
+            dim_feedforward=4 * embed_dim,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=depth)
+        self.norm = nn.LayerNorm(embed_dim)
+
+    def forward(
+        self,
+        x_num: Optional[torch.Tensor],
+        x_cat: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Forward pass returning the CLS token embedding."""
+        bsz = x_num.size(0) if x_num is not None else x_cat.size(0)  # type: ignore[arg-type]
+        tokens: list[torch.Tensor] = []
+
+        if self.num_linear is not None and x_num is not None:
+            num_tok = self.num_linear(x_num.unsqueeze(-1))  # (B, N_num, E)
+            tokens.append(num_tok)
+
+        if self.cat_embeddings and x_cat is not None:
+            cat_tok = [emb(x_cat[:, i]) for i, emb in enumerate(self.cat_embeddings)]
+            tokens.append(torch.stack(cat_tok, dim=1))
+
+        if tokens:
+            x = torch.cat(tokens, dim=1)
+        else:
+            x = torch.zeros(bsz, 0, self.embed_dim, device=self.cls_token.device, dtype=self.cls_token.dtype)
+
+        cls = self.cls_token.expand(bsz, -1, -1)
+        x = torch.cat([cls, x], dim=1)
+        x = self.transformer(x)
+        return self.norm(x[:, 0])

--- a/architectures/multimodal_survival.py
+++ b/architectures/multimodal_survival.py
@@ -6,45 +6,26 @@ import torch
 import torch.nn as nn
 from typing import Optional
 
-from .resnet3d import build_network
 from .fusion import CrossAttentionFiLMFusion
+from .resnet3d import build_network
 
 
 class MultimodalSurvivalNet(nn.Module):
-    """Single-stage multimodal survival model.
-
-    The model encodes imaging data with a 3D ResNet encoder and tabular data
-    with a small MLP. Features are fused using cross-attention followed by
-    FiLM modulation. The fused representation is used to predict the log-risk
-    for Cox-based objectives and can also serve as embedding for contrastive
-    losses.
-    """
+    """Single-stage multimodal survival model with pluggable encoders."""
 
     def __init__(
         self,
-        image_arch: str,
-        in_channels: int,
-        tabular_dim: int,
-        fusion_dim: int = 128,
+        image_encoder: nn.Module,
+        tabular_encoder: Optional[nn.Module],
+        embed_dim: int,
     ) -> None:
         super().__init__()
-        # Image encoder produces feature vector of size fusion_dim
-        self.image_encoder = build_network(
-            resnet_type=image_arch,
-            in_channels=in_channels,
-            num_classes=fusion_dim,
-        )
-        # Tabular encoder
-        self.tabular_encoder = nn.Sequential(
-            nn.Linear(tabular_dim, fusion_dim),
-            nn.ReLU(inplace=True),
-            nn.Linear(fusion_dim, fusion_dim),
-            nn.ReLU(inplace=True),
-        )
+        self.image_encoder = image_encoder
+        self.tabular_encoder = tabular_encoder
         self.fusion = CrossAttentionFiLMFusion(
-            img_dim=fusion_dim, tab_dim=fusion_dim, hidden_dim=fusion_dim
+            img_dim=embed_dim, tab_dim=embed_dim, hidden_dim=embed_dim
         )
-        self.risk_head = nn.Linear(fusion_dim, 1)
+        self.risk_head = nn.Linear(embed_dim, 1)
 
     def forward(
         self,
@@ -52,25 +33,13 @@ class MultimodalSurvivalNet(nn.Module):
         tabular: Optional[torch.Tensor],
         tab_mask: Optional[torch.Tensor] = None,
     ) -> dict:
-        """Forward pass.
-
-        Parameters
-        ----------
-        image : torch.Tensor
-            Image tensor ``(B, C, H, W, D)``.
-        tabular : torch.Tensor, optional
-            Tabular data ``(B, F)``.
-        tab_mask : torch.Tensor, optional
-            Boolean mask indicating which samples contain tabular data.
-
-        Returns
-        -------
-        dict
-            Dictionary with keys ``log_risk`` and modality embeddings.
-        """
         img_feat = self.image_encoder(image)
-        img_feat = img_feat.view(img_feat.size(0), -1)
-        tab_feat = self.tabular_encoder(tabular) if tabular is not None else None
+        tab_feat = None
+        if tabular is not None and self.tabular_encoder is not None:
+            try:
+                tab_feat = self.tabular_encoder(tabular)
+            except TypeError:  # e.g. FTTransformer expects x_num, x_cat
+                tab_feat = self.tabular_encoder(tabular, None)
         fused = self.fusion(img_feat, tab_feat, tab_mask)
         log_risk = self.risk_head(fused).squeeze(-1)
         return {
@@ -82,22 +51,54 @@ class MultimodalSurvivalNet(nn.Module):
 
 
 def build_multimodal_network(
-    image_arch: str = "resnet18",
+    img_encoder: str = "resnet3d",
+    tab_encoder: str = "mlp",
+    resnet_type: str = "resnet18",
     in_channels: int = 1,
     tabular_dim: int = 16,
-    fusion_dim: int = 128,
+    embed_dim: int = 128,
+    img_kwargs: dict | None = None,
+    tab_kwargs: dict | None = None,
 ) -> MultimodalSurvivalNet:
-    """Factory for :class:`MultimodalSurvivalNet`.
+    """Factory for :class:`MultimodalSurvivalNet` with configurable encoders."""
 
-    Parameters
-    ----------
-    image_arch : str, optional
-        Backbone architecture for images.
-    in_channels : int, optional
-        Number of image channels.
-    tabular_dim : int, optional
-        Dimension of tabular input features.
-    fusion_dim : int, optional
-        Dimension of intermediate fusion representation.
-    """
-    return MultimodalSurvivalNet(image_arch, in_channels, tabular_dim, fusion_dim)
+    img_kwargs = img_kwargs or {}
+    tab_kwargs = tab_kwargs or {}
+
+    if img_encoder == "resnet3d":
+        image_model = build_network(
+            resnet_type=resnet_type, in_channels=in_channels, num_classes=embed_dim
+        )
+    elif img_encoder == "swin3d":
+        from .swin3d import Swin3DEncoder
+
+        image_model = Swin3DEncoder(
+            in_ch=in_channels, embed_dim=embed_dim, **img_kwargs
+        )
+    else:  # pragma: no cover
+        raise ValueError(f"Unsupported image encoder: {img_encoder}")
+
+    if tab_encoder == "mlp":
+        tab_model = nn.Sequential(
+            nn.Linear(tabular_dim, embed_dim),
+            nn.ReLU(inplace=True),
+            nn.Linear(embed_dim, embed_dim),
+            nn.ReLU(inplace=True),
+        )
+    elif tab_encoder == "ft_transformer":
+        from .ft_transformer import FTTransformer
+
+        num_numeric = tab_kwargs.get("num_numeric", tabular_dim)
+        cat_card = tab_kwargs.get("cat_cardinalities")
+        tab_model = FTTransformer(
+            num_numeric=num_numeric,
+            cat_cardinalities=cat_card,
+            embed_dim=embed_dim,
+            n_heads=tab_kwargs.get("n_heads", 4),
+            depth=tab_kwargs.get("depth", 2),
+            dropout=tab_kwargs.get("dropout", 0.1),
+        )
+    else:  # pragma: no cover
+        raise ValueError(f"Unsupported tabular encoder: {tab_encoder}")
+
+    return MultimodalSurvivalNet(image_model, tab_model, embed_dim)

--- a/architectures/swin3d.py
+++ b/architectures/swin3d.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+try:
+    from monai.networks.nets import SwinUNETR
+except ImportError:  # pragma: no cover - handled in runtime
+    SwinUNETR = None
+
+
+class Swin3DEncoder(nn.Module):
+    """Swin-Transformer based encoder for 3D volumes.
+
+    This wraps :class:`monai.networks.nets.SwinUNETR` and exposes a simple
+    interface that converts an input volume into a global embedding vector.
+    Only the encoder path of ``SwinUNETR`` is utilised. The deepest feature
+    map is globally averaged and projected to the desired embedding size.
+    """
+
+    def __init__(
+        self,
+        in_ch: int = 1,
+        embed_dim: int = 256,
+        feature_size: int = 48,
+        window_size: int = 7,
+        depths: tuple[int, int, int, int] = (2, 2, 2, 2),
+        num_heads: tuple[int, int, int, int] = (3, 6, 12, 24),
+        dropout_path_rate: float = 0.1,
+    ) -> None:
+        super().__init__()
+        if SwinUNETR is None:  # pragma: no cover
+            raise ImportError("MONAI is required for Swin3DEncoder. Install with 'pip install monai'.")
+
+        self.backbone = SwinUNETR(
+            in_channels=in_ch,
+            out_channels=feature_size,
+            feature_size=feature_size,
+            depths=depths,
+            num_heads=num_heads,
+            window_size=window_size,
+            dropout_path_rate=dropout_path_rate,
+            spatial_dims=3,
+        )
+        self.proj = nn.Linear(feature_size * 16, embed_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode input volume to a global embedding.
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input tensor of shape ``(B, C, H, W, D)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Embedding tensor of shape ``(B, embed_dim)``.
+        """
+        hidden = self.backbone.swinViT(x, self.backbone.normalize)
+        deep = self.backbone.encoder10(hidden[4])
+        gap = deep.mean(dim=(2, 3, 4))
+        return self.proj(gap)

--- a/experiments/survival_analysis/template_experiment/config.yaml
+++ b/experiments/survival_analysis/template_experiment/config.yaml
@@ -19,11 +19,23 @@ dataset:
 
 # Model configuration
 model:
-  architecture: "resnet18"  # resnet18, resnet34, resnet50, resnet101, resnet152
-  in_channels: 1
-  num_classes: 1
-  init_mode: "random"  # random, pretrained
-  pretrained_path: ""
+  img_encoder: resnet3d        # or swin3d
+  tab_encoder: mlp             # or ft_transformer
+  embed_dim: 256
+
+swin3d:
+  feature_size: 48
+  window_size: 7
+  depths: [2, 2, 2, 2]
+  num_heads: [3, 6, 12, 24]
+  dropout_path_rate: 0.1
+
+ft_transformer:
+  n_heads: 4
+  depth: 2
+  dropout: 0.1
+  num_numeric: 24
+  cat_cardinalities: []
 
 # Training configuration
 training:
@@ -40,15 +52,13 @@ training:
   compile: false  # torch.compile
 
 # Loss configuration
-loss:
-  weights:
-    cox: 1.0
-    cpl: 0.0
-    tmcl: 0.0
-  cpl:
-    temperature: 1.0
-  tmcl:
-    margin: 1.0
+losses:
+  use_torchsurv_cox: true
+  lambda_cox: 1.0
+  lambda_cpl: 0.5
+  lambda_tmcl: 0.5
+  cpl: { tau0: 1.0, kappa: 0.5 }
+  tmcl: { mode: "triplet", pos_tau_months: 6, neg_tau_months: 24, beta_margin_per_year: 0.1, alpha_max: 0.5 }
 
 # DataLoader configuration
 dataloader:
@@ -62,8 +72,15 @@ sampler:
   event_fraction: 0.5  # fraction of events per batch when using EventAwareBatchSampler
 
 # Evaluation configuration
-evaluation:
-  eval_years: [1, 2, 3, 4, 5]  # Years at which to compute metrics
+eval:
+  horizons_years: [1,2,3,4,5]
+  brier_grid_years: [0.5, 1, 2, 3, 4, 5]
+
+early_stopping:
+  metric: "val_cindex"
+  mode: "max"
+  patience: 10
+  delta: 1.0e-4
 
 # Logging configuration
 logging:

--- a/finetune_scripts/finetune_survival.py
+++ b/finetune_scripts/finetune_survival.py
@@ -33,9 +33,17 @@ def parse_args():
     parser.add_argument('--fold_column', type=str, default='Fold_1', help='Column name for fold split (default: Fold_1)')
     parser.add_argument('--train_fold', type=str, default='train', help='Value in fold column for training data (default: train)')
     parser.add_argument('--val_fold', type=str, default='val', help='Value in fold column for validation data (default: val)')
-    parser.add_argument('--resnet', type=str, default='resnet18', 
-                       choices=['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152'], 
+    parser.add_argument('--resnet', type=str, default='resnet18',
+                       choices=['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152'],
                        help='ResNet architecture')
+    parser.add_argument('--img_encoder', type=str, default='resnet3d',
+                       choices=['resnet3d', 'swin3d'],
+                       help='Image encoder type')
+    parser.add_argument('--tab_encoder', type=str, default='mlp',
+                       choices=['mlp', 'ft_transformer'],
+                       help='Tabular encoder type')
+    parser.add_argument('--embed_dim', type=int, default=128,
+                       help='Shared embedding dimension')
     parser.add_argument('--image_size', type=int, nargs=3, default=[256, 256, 64], 
                        help='Image size (D, H, W)')
     parser.add_argument('--batch_size', type=int, default=6, help='Batch size')
@@ -196,9 +204,12 @@ def main():
 
     # Create dataloaders
     train_loader, val_loader = create_dataloaders(args)
+    args.tab_dim = train_loader.dataset[0][0].shape[0]
 
     # Setup model, optimizer, and scheduler
-    model, optimizer, scheduler = setup_model_and_optimizer(args, device)
+    model, optimizer, scheduler = setup_model_and_optimizer(
+        args, device, tabular_dim=args.tab_dim
+    )
     
     # Create mixed precision scaler
     scaler = torch.cuda.amp.GradScaler(enabled=args.amp) if args.amp else None


### PR DESCRIPTION
## Summary
- add `Swin3DEncoder` built on MONAI SwinUNETR for 3D imaging
- implement FT-Transformer for tabular features and pluggable encoders in `MultimodalSurvivalNet`
- extend trainer and configs to select between ResNet/Swin and MLP/FT-Transformer encoders

## Testing
- `pytest -q` *(fails: No module named 'distributed_utils', 'data', 'torchsurv')*


------
https://chatgpt.com/codex/tasks/task_e_68bbbdb8b4d8832fadad482c99a766e3